### PR TITLE
Create NFT Preview Popup Issue

### DIFF
--- a/src/Components/Dashboard/CreateNFT/createNft.js
+++ b/src/Components/Dashboard/CreateNFT/createNft.js
@@ -411,7 +411,6 @@ const CreateNft = props => {
                 {formValues.map((val, index) => (
                   <div className={styles.form__group__inner} key={index}>
                     <input
-                      style={{ width: "200px" }}
                       type="text"
                       value={val[`size_${val.id}`]}
                       placeholder="Ex. Size"
@@ -420,7 +419,6 @@ const CreateNft = props => {
 
                     <input
                       type="text"
-                      style={{ width: "200px" }}
                       value={val[`extension_${val.id}`]}
                       placeholder="Ex. 40"
                       onChange={handleChange(val.id, "extension")}
@@ -514,7 +512,7 @@ const CreateNft = props => {
               <div className={styles.mynft__box__description__wrapper}>
                 <h2>Title</h2>
                 <p>{details.title}</p>
-                <h2>description</h2>
+                <h2>Description</h2>
                 <p>{details?.description}</p>
                 <div className={styles.mynft__box__profile__info}>
                   <div className={styles.details__profile__picture}></div>

--- a/src/Components/Dashboard/CreateNFT/createNft.module.css
+++ b/src/Components/Dashboard/CreateNFT/createNft.module.css
@@ -381,7 +381,8 @@
 .nft__form__modal .modal__body__wrapper .mynft__box .mynft__box__description__wrapper h2 {
   font-size: 19.2px;
   margin-bottom: 0px;
-  padding-bottom: 10px;
+  padding-bottom: 5px;
+  padding-top: 10px;
 }
 
 .nft__form__modal .modal__body__wrapper .mynft__box .mynft__box__description__wrapper p {

--- a/src/Components/Dashboard/CreateNFT/createNft.module.scss
+++ b/src/Components/Dashboard/CreateNFT/createNft.module.scss
@@ -209,7 +209,8 @@
                 h2{
                     font-size: 19.2px;
                     margin-bottom: 0px;
-                    padding-bottom: 10px;
+                    padding-bottom: 5px;
+                    padding-top: 10px;
                 }
                 p{
                     font-size: 16.8px;


### PR DESCRIPTION
Fixed minor design issue for the properties size input  field.
Also, added some space before the title and description on the preview screen.


![create-nft-preview-desktop](https://user-images.githubusercontent.com/18471335/146751773-a249a8e7-ce86-442b-a0ab-3a875390366e.PNG)

![create-nft-preview-mobile](https://user-images.githubusercontent.com/18471335/146751780-9ed08ce6-c256-4b69-b1fb-f0546f909b11.PNG)
