### PR TITLE
[ NFTRWP-46 ]create and mint nft buttons are disabled on loading and reenabled if fails

### DIFF
--- a/src/Components/Dashboard/CreateNFT/createNft.js
+++ b/src/Components/Dashboard/CreateNFT/createNft.js
@@ -579,7 +579,7 @@ const CreateNft = (props) => {
           <div className={styles.multiple__btn__wrapper}>
             <button
               onClick={() => mineNft("mint")}
-              // disabled={loading}
+              disabled={loading}
               className={styles.next__btn}
             >
               Mint NFT

--- a/src/Components/Dashboard/CreateNFT/createNft.module.css
+++ b/src/Components/Dashboard/CreateNFT/createNft.module.css
@@ -541,3 +541,7 @@ Class to disable the dropdown
   -webkit-appearance: none;
   appearance: none;
 }
+
+.next__btn:disabled {
+  background-color: #bdbdbd !important;
+}


### PR DESCRIPTION
Create and mint nft buttons are disabled on loading and reenabled if fails.