### PR TITLE
NFTRWP-92-settings-update-the-label-of-full-name

### DIFF
--- a/src/Components/Dashboard/Settings/index.js
+++ b/src/Components/Dashboard/Settings/index.js
@@ -298,7 +298,7 @@ const Settings = () => {
             <div className="modal__title__wrapper">
               <Modal.Title>
                 <div className={styles.modal__header}>
-                  <h2>Change {details}</h2>
+                  <h2>Change {details.replace(/_/g, " ")}</h2>
                 </div>
               </Modal.Title>
             </div>


### PR DESCRIPTION
Nftrwp 92 settings update the label of the full name
Changed the full_name to full name in the settings update label, added a function to remove _ from snake case variable names, thus "full_name" is now visible as "full name".
