### PR TITLE
Tapjoy postback

### DIFF
--- a/src/Components/Dashboard/CreateNFT/createNft.js
+++ b/src/Components/Dashboard/CreateNFT/createNft.js
@@ -164,6 +164,10 @@ const CreateNft = (props) => {
     let nftDetail = { ...details };
     nftDetail.attributes = formValues;
     nftDetail.owner_id = user.user_id;
+    nftDetail.tracker = {
+      id: '13', // random value. it may need to be static or linked to a specific customer in the future
+      value: transactionId
+    }
 
     if (type === "mint") {
       nftDetail.action_type = "mine";


### PR DESCRIPTION
Send the transaction_id from the URL to the backend when the user creates an NFT. It qualifies the conversion on the Tapjoy side