### PR TITLE
Fix image over flowing card border in send nft modal

### DIFF
--- a/src/Components/Dashboard/CreateNFT/createNft.module.css
+++ b/src/Components/Dashboard/CreateNFT/createNft.module.css
@@ -361,6 +361,7 @@
   border-radius: 12px;
   background-color: #fff;
   margin-bottom: 10px;
+  overflow: hidden;  
 }
 
 .nft__form__modal .modal__body__wrapper .mynft__box .mynft__box__image__wrapper {

--- a/src/Components/Dashboard/CreateNFT/createNft.module.scss
+++ b/src/Components/Dashboard/CreateNFT/createNft.module.scss
@@ -190,6 +190,7 @@
       border-radius: 12px;
       background-color: #fff;
       margin-bottom: 10px;
+      overflow: hidden;
       .mynft__box__image__wrapper {
         position: relative;
         img {


### PR DESCRIPTION
Evidence, that issue has been fixed:
![image](https://user-images.githubusercontent.com/97716187/150346193-158bc4be-d565-47b0-abcd-8cf24bc49871.png)
